### PR TITLE
Add streaming and prompt caching to essay proofreader

### DIFF
--- a/essay.html
+++ b/essay.html
@@ -85,7 +85,9 @@
 
       const resultArea    = document.getElementById('result-area');
       const resultContent = document.getElementById('result-content');
-      resultArea.hidden   = true;
+      resultContent.innerHTML = '';
+      resultArea.hidden = false;
+      resultArea.scrollIntoView({ behavior: 'smooth' });
 
       try {
         const res = await fetch(WORKER_URL, {
@@ -99,16 +101,42 @@
           throw new Error(`サーバーエラー (${res.status}): ${msg}`);
         }
 
-        const data = await res.json();
-        const correction = data.correction;
-        if (!correction) {
-          throw new Error('Workerからの応答に添削結果がありません。\n' + JSON.stringify(data));
+        // SSE ストリームを逐次読み取り、テキストが届くたびに描画する
+        const reader  = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer   = '';
+        let fullText = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop(); // 最後の不完全な行は次回に持ち越す
+
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue;
+            const raw = line.slice(6).trim();
+            if (!raw) continue;
+            try {
+              const evt = JSON.parse(raw);
+              if (evt.type === 'content_block_delta' && evt.delta?.type === 'text_delta') {
+                fullText += evt.delta.text;
+                resultContent.innerHTML = renderMarkdown(fullText);
+              }
+            } catch {
+              // 不完全な JSON は無視
+            }
+          }
         }
-        resultContent.innerHTML = renderMarkdown(correction);
-        resultArea.hidden = false;
-        resultArea.scrollIntoView({ behavior: 'smooth' });
+
+        if (!fullText) {
+          resultContent.innerHTML = '<p>（添削結果を取得できませんでした）</p>';
+        }
 
       } catch (err) {
+        resultArea.hidden = true;
         alert('エラーが発生しました:\n' + err.message);
       } finally {
         btn.disabled = false;


### PR DESCRIPTION
worker.js:
- Add anthropic-beta: prompt-caching-2024-07-31 header
- Convert system to array format with cache_control: ephemeral so the fixed system prompt is cached (reduces latency on repeat calls)
- Add stream: true and forward Claude's SSE body directly to client

essay.html:
- Show result area immediately before stream begins
- Replace res.json() with ReadableStream SSE reader
- Render markdown progressively as each content_block_delta arrives

https://claude.ai/code/session_01Pmsj27Khmp4WeG5nJcNa8M