### PR TITLE
Add essay correction history with localStorage

### DIFF
--- a/essay.html
+++ b/essay.html
@@ -54,6 +54,14 @@
         <div id="result-content" class="result-content"></div>
       </div>
     </section>
+
+    <section class="history-section" id="history-section" hidden>
+      <div class="history-header">
+        <h3 class="history-title">📋 過去の添削履歴</h3>
+        <button class="btn-hist-clear" onclick="clearAllHistory()">すべて削除</button>
+      </div>
+      <div id="history-list" class="history-list"></div>
+    </section>
   </main>
 
   <footer>
@@ -136,6 +144,8 @@
 
         if (!fullText) {
           resultContent.innerHTML = '<p>（添削結果を取得できませんでした）</p>';
+        } else {
+          saveToHistory(question, answer, fullText);
         }
 
       } catch (err) {
@@ -184,6 +194,78 @@
       if (inList) html += '</ul>';
       return html;
     }
+
+    // ===================================================
+    // 添削履歴 (localStorage)
+    // ===================================================
+    const HIST_KEY = 'essay_history';
+    const MAX_HIST = 20;
+
+    function loadHistories() {
+      try { return JSON.parse(localStorage.getItem(HIST_KEY)) || []; }
+      catch { return []; }
+    }
+
+    function saveToHistory(question, answer, correction) {
+      const list = loadHistories();
+      list.unshift({ id: Date.now(), date: new Date().toISOString(), question, answer, correction });
+      if (list.length > MAX_HIST) list.length = MAX_HIST;
+      localStorage.setItem(HIST_KEY, JSON.stringify(list));
+      renderHistoryList();
+    }
+
+    function renderHistoryList() {
+      const list = loadHistories();
+      const section = document.getElementById('history-section');
+      const container = document.getElementById('history-list');
+      if (list.length === 0) { section.hidden = true; return; }
+      section.hidden = false;
+      container.innerHTML = list.map(h => {
+        const d = new Date(h.date);
+        const pad = n => String(n).padStart(2, '0');
+        const dateStr = `${d.getFullYear()}/${pad(d.getMonth()+1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+        const qPrev = h.question ? escapeHtml(h.question.slice(0, 45)) + (h.question.length > 45 ? '…' : '') : '（問題文なし）';
+        return `
+          <div class="history-item" id="hist-${h.id}">
+            <div class="history-item-row">
+              <div class="history-item-meta">
+                <span class="history-date">${dateStr}</span>
+                <span class="history-preview">${qPrev}</span>
+              </div>
+              <div class="history-item-actions">
+                <button class="btn-hist-view" onclick="toggleHistoryItem(${h.id})">表示</button>
+                <button class="btn-hist-del" onclick="deleteHistoryItem(${h.id})">削除</button>
+              </div>
+            </div>
+            <div class="history-item-body" id="hist-body-${h.id}" hidden>
+              <p class="history-answer-preview"><strong>解答：</strong>${escapeHtml(h.answer.slice(0, 80))}${h.answer.length > 80 ? '…' : ''}</p>
+              <div class="result-content">${renderMarkdown(h.correction)}</div>
+            </div>
+          </div>`;
+      }).join('');
+    }
+
+    function toggleHistoryItem(id) {
+      const body = document.getElementById(`hist-body-${id}`);
+      const btn  = document.querySelector(`#hist-${id} .btn-hist-view`);
+      body.hidden = !body.hidden;
+      btn.textContent = body.hidden ? '表示' : '閉じる';
+    }
+
+    function deleteHistoryItem(id) {
+      const list = loadHistories().filter(h => h.id !== id);
+      localStorage.setItem(HIST_KEY, JSON.stringify(list));
+      renderHistoryList();
+    }
+
+    function clearAllHistory() {
+      if (!confirm('すべての履歴を削除しますか？')) return;
+      localStorage.removeItem(HIST_KEY);
+      renderHistoryList();
+    }
+
+    // 初期描画
+    renderHistoryList();
   </script>
 
 </body>

--- a/style.css
+++ b/style.css
@@ -500,6 +500,138 @@ main {
   font-size: 0.85em;
 }
 
+/* ---- History Section ---- */
+
+.history-section {
+  margin-top: 2rem;
+}
+
+.history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.history-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.btn-hist-clear {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  border-radius: 5px;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.btn-hist-clear:hover {
+  border-color: #dc2626;
+  color: #dc2626;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.history-item {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.history-item-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.7rem 1rem;
+}
+
+.history-item-meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  overflow: hidden;
+}
+
+.history-date {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.history-preview {
+  font-size: 0.85rem;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-item-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.btn-hist-view,
+.btn-hist-del {
+  border: 1px solid var(--color-border);
+  border-radius: 5px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.btn-hist-view {
+  background: var(--color-accent);
+  color: #fff;
+  border-color: var(--color-accent);
+}
+
+.btn-hist-view:hover {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+}
+
+.btn-hist-del {
+  background: none;
+  color: var(--color-text-muted);
+}
+
+.btn-hist-del:hover {
+  background: #fee2e2;
+  border-color: #dc2626;
+  color: #dc2626;
+}
+
+[data-theme="dark"] .btn-hist-del:hover {
+  background: #3d1515;
+}
+
+.history-item-body {
+  padding: 1rem 1.25rem 1.25rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.history-answer-preview {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  margin-bottom: 0.75rem;
+}
+
 /* ---- Footer ---- */
 
 footer {


### PR DESCRIPTION
- essay.html: add history section (HTML + JS) below the result area
  - saveToHistory() stores up to 20 entries in localStorage after each successful correction
  - renderHistoryList() renders saved entries on page load and after save
  - toggleHistoryItem() expands/collapses individual correction details
  - deleteHistoryItem() and clearAllHistory() for removal
- style.css: add styles for history section, items, and action buttons (view/delete), with dark mode support

https://claude.ai/code/session_01Pmsj27Khmp4WeG5nJcNa8M