### PR TITLE
Implement multi-type answer example selection feature

### DIFF
--- a/essay.html
+++ b/essay.html
@@ -46,6 +46,32 @@
             placeholder="英作文をここに入力してください…"></textarea>
         </div>
 
+        <div class="form-group">
+          <label>解答例タイプ（複数選択可）</label>
+          <div class="checkbox-group">
+            <label class="checkbox-label">
+              <input type="checkbox" id="type-A" name="types" value="A" checked>
+              A（原文ベース）
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="type-B" name="types" value="B">
+              B（英検2級）
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="type-C" name="types" value="C">
+              C（英検準1級）
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="type-D" name="types" value="D">
+              D（英検1級）
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="type-E" name="types" value="E">
+              E（別アプローチ版）
+            </label>
+          </div>
+        </div>
+
         <button id="submit-btn" class="btn-submit" onclick="submitEssay()">✏️ 添削する</button>
       </div>
 
@@ -75,6 +101,46 @@
     // worker.js をデプロイした後、URLを差し替えてください
     // ===================================================
     const WORKER_URL = 'https://essay-proxy.yoshida-tom-ac.workers.dev';
+    const TYPES_KEY = 'essay_types_selection';
+
+    // localStorage に保存されたタイプを復元
+    function loadSavedTypes() {
+      try {
+        const saved = localStorage.getItem(TYPES_KEY);
+        return saved ? JSON.parse(saved) : ['A'];
+      } catch {
+        return ['A'];
+      }
+    }
+
+    // タイプ選択を保存
+    function saveSelectedTypes() {
+      const checkboxes = document.querySelectorAll('input[name="types"]:checked');
+      const types = Array.from(checkboxes).map(cb => cb.value);
+      if (types.length === 0) {
+        // 何も選択されていない場合は A をデフォルトに
+        localStorage.setItem(TYPES_KEY, JSON.stringify(['A']));
+        document.getElementById('type-A').checked = true;
+      } else {
+        localStorage.setItem(TYPES_KEY, JSON.stringify(types));
+      }
+    }
+
+    // 初期化：保存されたタイプを復元
+    function restoreTypes() {
+      const saved = loadSavedTypes();
+      document.querySelectorAll('input[name="types"]').forEach(cb => {
+        cb.checked = saved.includes(cb.value);
+      });
+    }
+
+    // チェックボックス変更時に自動保存
+    document.addEventListener('DOMContentLoaded', function() {
+      restoreTypes();
+      document.querySelectorAll('input[name="types"]').forEach(cb => {
+        cb.addEventListener('change', saveSelectedTypes);
+      });
+    });
 
     async function submitEssay() {
       const question = document.getElementById('question').value.trim();
@@ -101,10 +167,14 @@
       resultArea.scrollIntoView({ behavior: 'smooth' });
 
       try {
+        // 選択されたタイプを取得
+        const checkboxes = document.querySelectorAll('input[name="types"]:checked');
+        const types = Array.from(checkboxes).map(cb => cb.value);
+
         const res = await fetch(WORKER_URL, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ question, answer }),
+          body: JSON.stringify({ question, answer, types }),
         });
 
         if (!res.ok) {

--- a/style.css
+++ b/style.css
@@ -420,6 +420,36 @@ main {
   min-height: 200px;
 }
 
+/* ---- Checkbox Group ---- */
+
+.checkbox-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--color-text);
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkbox-label input[type="checkbox"] {
+  cursor: pointer;
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--color-accent);
+}
+
+.checkbox-label:hover {
+  color: var(--color-accent);
+}
+
 .btn-submit {
   display: inline-block;
   background: var(--color-accent);


### PR DESCRIPTION
- Add type-based system prompt generation in worker.js (types A-E)
- Support multiple checkbox selection in essay.html
- Add localStorage persistence for user type preferences
- Define 5 answer example types:
  - A: Original text-based improvement
  - B: CEFR A2-B1 (Eiken Grade 2)
  - C: CEFR B1-B2 (Eiken Pre-1)
  - D: CEFR B2-C1 (Eiken Grade 1)
  - E: CEFR B1-B2 alternative approach
- Add checkbox styling to style.css for dark mode support

https://claude.ai/code/session_018iChpTiL8pLnbVAQRmGZ8y