### PR TITLE
Implement essay correction for three types: free essay, translation, …

### DIFF
--- a/essay.html
+++ b/essay.html
@@ -49,19 +49,28 @@
 
   <main>
     <section class="essay-section">
-      <h2>ふつうの英作文 AI添削</h2>
+      <h2>英作文 AI添削</h2>
       <p class="section-desc">添削の「語数」は信じたらあかんﾃﾞ 「～は必須！」も信じていいかわからんﾃﾞ　図表はﾑﾘやﾃﾞ</p>
 
-      <div class="essay-card">
+      <!-- タブナビゲーション -->
+      <div class="tab-nav">
+        <button class="tab-btn tab-btn--active" data-tab="free-essay">ふつうの英作文</button>
+        <button class="tab-btn" data-tab="translation">和文英訳</button>
+        <button class="tab-btn" data-tab="diagram-essay">図表付き英作文</button>
+      </div>
+
+      <!-- タブ1: ふつうの英作文 -->
+      <div class="essay-card tab-content tab-content--active" id="free-essay">
+        <h3 class="essay-subheading">ふつうの英作文 AI添削</h3>
         <div class="form-group">
-          <label for="question">問題文（テーマ・指示文）</label>
-          <textarea id="question" class="essay-textarea" rows="4"
+          <label for="question-free">問題文（テーマ・指示文）</label>
+          <textarea id="question-free" class="essay-textarea" rows="4"
             placeholder="例: Describe the advantages of studying abroad in about 100 words."></textarea>
         </div>
 
         <div class="form-group">
-          <label for="answer">あなたの作品</label>
-          <textarea id="answer" class="essay-textarea essay-textarea--answer" rows="10"
+          <label for="answer-free">あなたの作品</label>
+          <textarea id="answer-free" class="essay-textarea essay-textarea--answer" rows="10"
             placeholder="英作文をここに入力してください…"></textarea>
         </div>
 
@@ -102,7 +111,60 @@
           </div>
         </div>
 
-        <button id="submit-btn" class="btn-submit" onclick="submitEssay()">✏️ 添削する</button>
+        <button class="btn-submit" onclick="submitEssay('free-essay')">✏️ 添削する</button>
+      </div>
+
+      <!-- タブ2: 和文英訳 -->
+      <div class="essay-card tab-content" id="translation">
+        <h3 class="essay-subheading">和文英訳 AI添削</h3>
+        <div class="form-group">
+          <label for="japanese-text">日本語テキスト</label>
+          <textarea id="japanese-text" class="essay-textarea" rows="6"
+            placeholder="日本語を入力してください…"></textarea>
+        </div>
+
+        <div class="form-group">
+          <label for="answer-translation">あなたの英訳</label>
+          <textarea id="answer-translation" class="essay-textarea essay-textarea--answer" rows="10"
+            placeholder="英訳をここに入力してください…"></textarea>
+        </div>
+
+        <button class="btn-submit" onclick="submitEssay('translation')">✏️ 添削する</button>
+      </div>
+
+      <!-- タブ3: 図表付き英作文 -->
+      <div class="essay-card tab-content" id="diagram-essay">
+        <h3 class="essay-subheading">図表付き英作文 AI添削</h3>
+        <div class="form-group">
+          <label for="question-diagram">問題文（テーマ・指示文）</label>
+          <textarea id="question-diagram" class="essay-textarea" rows="4"
+            placeholder="例: Describe the chart below in about 150 words."></textarea>
+        </div>
+
+        <div class="form-group">
+          <label for="image-upload">図表画像をアップロード</label>
+          <div class="image-upload-area" id="image-upload-area" ondrop="handleDrop(event)" ondragover="handleDragOver(event)" ondragleave="handleDragLeave(event)">
+            <input type="file" id="image-upload" accept="image/*" onchange="handleImageSelect(event)" style="display: none;">
+            <input type="file" id="camera-input" accept="image/*" capture="environment" style="display: none;">
+            <div class="upload-placeholder">
+              <p>📸 ここに画像をドラッグ&ドロップ</p>
+              <p class="upload-hint">または、下のボタンから選択してください</p>
+            </div>
+            <div id="image-preview" class="image-preview" hidden></div>
+          </div>
+          <div class="upload-buttons">
+            <button class="btn-upload" onclick="document.getElementById('image-upload').click()">📁 ファイルを選択</button>
+            <button class="btn-upload" onclick="document.getElementById('camera-input').click()">📷 カメラで撮影</button>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="answer-diagram">あなたの作品</label>
+          <textarea id="answer-diagram" class="essay-textarea essay-textarea--answer" rows="10"
+            placeholder="英作文をここに入力してください…"></textarea>
+        </div>
+
+        <button class="btn-submit" onclick="submitEssay('diagram-essay')">✏️ 添削する</button>
       </div>
 
       <div id="result-area" class="result-area" hidden>
@@ -133,6 +195,9 @@
     const WORKER_URL = 'https://essay-proxy.yoshida-tom-ac.workers.dev';
     const TYPES_KEY = 'essay_types_selection';
     const CUSTOM_KEY = 'essay_custom_instruction';
+
+    // グローバル変数：アップロードされた画像
+    let uploadedImageBase64 = null;
 
     // localStorage に保存されたタイプを復元
     function loadSavedTypes() {
@@ -188,8 +253,110 @@
       toggleText.textContent = section.hidden ? '▶ F：解答例を詳しく指定する' : '▼ F：解答例を詳しく指定する';
     }
 
+    // ===================================================
+    // タブ切り替え機能
+    // ===================================================
+    function switchTab(tabId) {
+      // すべてのタブコンテンツを非表示
+      document.querySelectorAll('.tab-content').forEach(el => {
+        el.classList.remove('tab-content--active');
+      });
+
+      // すべてのタブボタンを非アクティブ
+      document.querySelectorAll('.tab-btn').forEach(btn => {
+        btn.classList.remove('tab-btn--active');
+      });
+
+      // 選択されたタブを表示
+      document.getElementById(tabId).classList.add('tab-content--active');
+
+      // 選択されたタブボタンをアクティブ
+      document.querySelector(`[data-tab="${tabId}"]`).classList.add('tab-btn--active');
+    }
+
+    // ===================================================
+    // 画像アップロード機能
+    // ===================================================
+    function handleDragOver(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      document.getElementById('image-upload-area').classList.add('drag-over');
+    }
+
+    function handleDragLeave(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      document.getElementById('image-upload-area').classList.remove('drag-over');
+    }
+
+    function handleDrop(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      document.getElementById('image-upload-area').classList.remove('drag-over');
+
+      const files = e.dataTransfer.files;
+      if (files.length > 0) {
+        handleImageSelect({ target: { files } });
+      }
+    }
+
+    function handleImageSelect(e) {
+      const file = e.target.files[0];
+      if (!file) return;
+
+      // ファイル形式チェック
+      if (!file.type.startsWith('image/')) {
+        alert('画像ファイルを選択してください。');
+        return;
+      }
+
+      // ファイルサイズチェック（10MBまで）
+      if (file.size > 10 * 1024 * 1024) {
+        alert('ファイルサイズは10MB以下にしてください。');
+        return;
+      }
+
+      const reader = new FileReader();
+      reader.onload = function(event) {
+        uploadedImageBase64 = event.target.result;
+        displayImagePreview(file.name);
+      };
+      reader.readAsDataURL(file);
+    }
+
+    function displayImagePreview(fileName) {
+      const preview = document.getElementById('image-preview');
+      const placeholder = document.querySelector('.upload-placeholder');
+
+      placeholder.style.display = 'none';
+      preview.innerHTML = `
+        <div class="image-preview-item">
+          <img src="${uploadedImageBase64}" alt="プレビュー">
+          <p class="image-preview-name">${fileName}</p>
+          <button class="btn-remove-image" onclick="removeImage()">削除</button>
+        </div>
+      `;
+      preview.hidden = false;
+    }
+
+    function removeImage() {
+      uploadedImageBase64 = null;
+      document.getElementById('image-upload').value = '';
+      document.getElementById('camera-input').value = '';
+      document.getElementById('image-preview').innerHTML = '';
+      document.getElementById('image-preview').hidden = true;
+      document.querySelector('.upload-placeholder').style.display = 'block';
+    }
+
     // チェックボックス変更時に自動保存
     document.addEventListener('DOMContentLoaded', function() {
+      // タブボタンにイベントリスナー追加
+      document.querySelectorAll('.tab-btn').forEach(btn => {
+        btn.addEventListener('click', function() {
+          switchTab(this.dataset.tab);
+        });
+      });
+
       restoreTypes();
       document.querySelectorAll('input[name="types"]').forEach(cb => {
         cb.addEventListener('change', saveSelectedTypes);
@@ -200,13 +367,66 @@
       document.getElementById('custom-instruction').addEventListener('blur', saveCustomInstruction);
     });
 
-    async function submitEssay() {
-      const question = document.getElementById('question').value.trim();
-      const answer   = document.getElementById('answer').value.trim();
+    async function submitEssay(tabType) {
+      let payload = {};
 
-      if (!answer) {
-        alert('解答を入力してください。');
-        return;
+      // タイプに応じてペイロードを構築
+      if (tabType === 'free-essay') {
+        const question = document.getElementById('question-free').value.trim();
+        const answer = document.getElementById('answer-free').value.trim();
+
+        if (!answer) {
+          alert('解答を入力してください。');
+          return;
+        }
+
+        const checkboxes = document.querySelectorAll('input[name="types"]:checked');
+        const types = Array.from(checkboxes).map(cb => cb.value);
+        const customInstruction = document.getElementById('custom-instruction').value.trim();
+
+        payload = {
+          essayType: 'free-essay',
+          question,
+          answer,
+          types,
+          customInstruction
+        };
+
+      } else if (tabType === 'translation') {
+        const japaneseText = document.getElementById('japanese-text').value.trim();
+        const answer = document.getElementById('answer-translation').value.trim();
+
+        if (!japaneseText || !answer) {
+          alert('日本語と英訳の両方を入力してください。');
+          return;
+        }
+
+        payload = {
+          essayType: 'translation',
+          japaneseText,
+          answer
+        };
+
+      } else if (tabType === 'diagram-essay') {
+        const question = document.getElementById('question-diagram').value.trim();
+        const answer = document.getElementById('answer-diagram').value.trim();
+
+        if (!answer) {
+          alert('解答を入力してください。');
+          return;
+        }
+
+        if (!uploadedImageBase64) {
+          alert('図表画像をアップロードしてください。');
+          return;
+        }
+
+        payload = {
+          essayType: 'diagram-essay',
+          question,
+          answer,
+          imageBase64: uploadedImageBase64
+        };
       }
 
       if (WORKER_URL.includes('YOUR_WORKER_NAME')) {
@@ -214,28 +434,28 @@
         return;
       }
 
-      const btn = document.getElementById('submit-btn');
+      // タイプに応じてボタンを特定
+      const allButtons = document.querySelectorAll('.btn-submit');
+      let btn = allButtons[Array.from(allButtons).length - 1]; // 最後のボタンを使う（複雑なので改善の余地あり）
+      const activeTab = document.querySelector('.tab-content--active');
+      btn = activeTab.querySelector('.btn-submit');
+
       btn.disabled = true;
       btn.textContent = '添削中…';
 
-      const resultArea    = document.getElementById('result-area');
+      const resultArea = document.getElementById('result-area');
       const resultContent = document.getElementById('result-content');
       resultContent.innerHTML = '';
       resultArea.hidden = false;
       resultArea.scrollIntoView({ behavior: 'smooth' });
 
       try {
-        // 選択されたタイプと custom instruction を取得
-        const checkboxes = document.querySelectorAll('input[name="types"]:checked');
-        const types = Array.from(checkboxes).map(cb => cb.value);
-        const customInstruction = document.getElementById('custom-instruction').value.trim();
-
-        console.log('[Essay] Sending request with types:', types, 'customInstruction:', customInstruction);
+        console.log('[Essay] Sending request:', payload);
 
         const res = await fetch(WORKER_URL, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ question, answer, types, customInstruction }),
+          body: JSON.stringify(payload),
         });
 
         console.log('[Essay] Response status:', res.status, 'Content-Type:', res.headers.get('content-type'));
@@ -247,9 +467,9 @@
         }
 
         // SSE ストリームを逐次読み取り、テキストが届くたびに描画する
-        const reader  = res.body.getReader();
+        const reader = res.body.getReader();
         const decoder = new TextDecoder();
-        let buffer   = '';
+        let buffer = '';
         let fullText = '';
         let eventCount = 0;
 
@@ -262,7 +482,7 @@
 
           buffer += decoder.decode(value, { stream: true });
           const lines = buffer.split('\n');
-          buffer = lines.pop(); // 最後の不完全な行は次回に持ち越す
+          buffer = lines.pop();
 
           for (const line of lines) {
             if (!line.startsWith('data: ')) continue;
@@ -288,7 +508,7 @@
           resultContent.innerHTML = '<p>エラー：サーバーから添削結果を受け取れませんでした。ブラウザのコンソールを確認してください。</p>';
           console.error('[Essay] No text received. Check Worker logs and API response.');
         } else {
-          saveToHistory(question, answer, fullText);
+          saveToHistory(tabType, payload, fullText);
         }
 
       } catch (err) {
@@ -350,9 +570,16 @@
       catch { return []; }
     }
 
-    function saveToHistory(question, answer, correction) {
+    function saveToHistory(essayType, payload, correction) {
       const list = loadHistories();
-      list.unshift({ id: Date.now(), date: new Date().toISOString(), question, answer, correction });
+      const historyItem = {
+        id: Date.now(),
+        date: new Date().toISOString(),
+        essayType,
+        payload,
+        correction
+      };
+      list.unshift(historyItem);
       if (list.length > MAX_HIST) list.length = MAX_HIST;
       localStorage.setItem(HIST_KEY, JSON.stringify(list));
       renderHistoryList();
@@ -368,13 +595,36 @@
         const d = new Date(h.date);
         const pad = n => String(n).padStart(2, '0');
         const dateStr = `${d.getFullYear()}/${pad(d.getMonth()+1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
-        const qPrev = h.question ? escapeHtml(h.question.slice(0, 45)) + (h.question.length > 45 ? '…' : '') : '（問題文なし）';
+
+        // タイプに応じてプレビューを生成
+        let preview = '（情報なし）';
+        let answerPreview = '（情報なし）';
+
+        if (h.essayType === 'free-essay') {
+          preview = h.payload.question ? escapeHtml(h.payload.question.slice(0, 45)) + (h.payload.question.length > 45 ? '…' : '') : '（問題文なし）';
+          answerPreview = h.payload.answer ? escapeHtml(h.payload.answer.slice(0, 80)) + (h.payload.answer.length > 80 ? '…' : '') : '（解答なし）';
+        } else if (h.essayType === 'translation') {
+          preview = h.payload.japaneseText ? escapeHtml(h.payload.japaneseText.slice(0, 45)) + (h.payload.japaneseText.length > 45 ? '…' : '') : '（日本語なし）';
+          answerPreview = h.payload.answer ? escapeHtml(h.payload.answer.slice(0, 80)) + (h.payload.answer.length > 80 ? '…' : '') : '（英訳なし）';
+        } else if (h.essayType === 'diagram-essay') {
+          preview = h.payload.question ? escapeHtml(h.payload.question.slice(0, 45)) + (h.payload.question.length > 45 ? '…' : '') : '（問題文なし）';
+          answerPreview = h.payload.answer ? escapeHtml(h.payload.answer.slice(0, 80)) + (h.payload.answer.length > 80 ? '…' : '') : '（解答なし）';
+        }
+
+        // タイプラベル
+        const typeLabel = {
+          'free-essay': 'ふつうの英作文',
+          'translation': '和文英訳',
+          'diagram-essay': '図表付き英作文'
+        }[h.essayType] || 'その他';
+
         return `
           <div class="history-item" id="hist-${h.id}">
             <div class="history-item-row">
               <div class="history-item-meta">
                 <span class="history-date">${dateStr}</span>
-                <span class="history-preview">${qPrev}</span>
+                <span class="history-type-badge">${typeLabel}</span>
+                <span class="history-preview">${preview}</span>
               </div>
               <div class="history-item-actions">
                 <button class="btn-hist-view" onclick="toggleHistoryItem(${h.id})">表示</button>
@@ -382,7 +632,7 @@
               </div>
             </div>
             <div class="history-item-body" id="hist-body-${h.id}" hidden>
-              <p class="history-answer-preview"><strong>解答：</strong>${escapeHtml(h.answer.slice(0, 80))}${h.answer.length > 80 ? '…' : ''}</p>
+              <p class="history-answer-preview"><strong>解答：</strong>${answerPreview}</p>
               <div class="result-content">${renderMarkdown(h.correction)}</div>
             </div>
           </div>`;

--- a/style.css
+++ b/style.css
@@ -56,6 +56,25 @@
   background: rgba(59, 130, 246, 0.06);
 }
 
+[data-theme="dark"] .image-upload-area {
+  background: rgba(59, 130, 246, 0.04);
+  border-color: #334155;
+}
+
+[data-theme="dark"] .image-upload-area.drag-over {
+  background: rgba(59, 130, 246, 0.1);
+  border-color: var(--color-accent);
+}
+
+[data-theme="dark"] .image-preview-item {
+  background: #243044;
+}
+
+[data-theme="dark"] .history-type-badge {
+  background: rgba(59, 130, 246, 0.2);
+  color: #60a5fa;
+}
+
 /* ---- Theme Toggle Button ---- */
 
 .theme-toggle {
@@ -552,6 +571,189 @@ main {
   margin-bottom: 0.5rem;
 }
 
+.essay-section h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: var(--color-accent);
+}
+
+/* ---- Tab Navigation ---- */
+
+.tab-nav {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 2px solid var(--color-border);
+  overflow-x: auto;
+}
+
+.tab-btn {
+  padding: 0.7rem 1.2rem;
+  border: none;
+  background: none;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  border-bottom: 3px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -2px;
+}
+
+.tab-btn:hover {
+  color: var(--color-accent);
+}
+
+.tab-btn--active {
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+}
+
+/* ---- Tab Content ---- */
+
+.tab-content {
+  display: none;
+}
+
+.tab-content--active {
+  display: block;
+}
+
+.essay-subheading {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+/* ---- Image Upload Area ---- */
+
+.image-upload-area {
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius);
+  padding: 2rem;
+  text-align: center;
+  background: rgba(37, 99, 235, 0.02);
+  transition: background 0.15s, border-color 0.15s;
+  cursor: pointer;
+  margin-bottom: 0.75rem;
+}
+
+.image-upload-area.drag-over {
+  background: rgba(37, 99, 235, 0.08);
+  border-color: var(--color-accent);
+}
+
+.upload-placeholder {
+  pointer-events: none;
+}
+
+.upload-placeholder p {
+  font-size: 0.9rem;
+  color: var(--color-text);
+  margin-bottom: 0.25rem;
+}
+
+.upload-placeholder p:first-child {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.upload-hint {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.image-preview {
+  padding: 1rem;
+}
+
+.image-preview-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: var(--color-bg);
+  border-radius: var(--radius);
+  padding: 1rem;
+}
+
+.image-preview-item img {
+  max-width: 120px;
+  max-height: 120px;
+  border-radius: 5px;
+  object-fit: cover;
+}
+
+.image-preview-name {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.btn-remove-image {
+  padding: 0.3rem 0.7rem;
+  background: #fee2e2;
+  border: 1px solid #dc2626;
+  border-radius: 3px;
+  color: #dc2626;
+  font-size: 0.8rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.btn-remove-image:hover {
+  background: #fecaca;
+}
+
+[data-theme="dark"] .btn-remove-image {
+  background: #3d1515;
+}
+
+[data-theme="dark"] .btn-remove-image:hover {
+  background: #5a1e1e;
+}
+
+.upload-buttons {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.btn-upload {
+  flex: 1;
+  padding: 0.5rem 1rem;
+  background: var(--color-accent);
+  color: white;
+  border: none;
+  border-radius: 5px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-upload:hover {
+  background: var(--color-accent-hover);
+}
+
+@media (max-width: 600px) {
+  .upload-buttons {
+    flex-direction: column;
+  }
+
+  .image-preview-item {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
 .essay-card {
   background: var(--color-surface);
   border-radius: var(--radius);
@@ -821,6 +1023,18 @@ main {
 .history-date {
   font-size: 0.75rem;
   color: var(--color-text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.history-type-badge {
+  display: inline-block;
+  background: rgba(37, 99, 235, 0.15);
+  color: var(--color-accent);
+  padding: 0.2rem 0.6rem;
+  border-radius: 99px;
+  font-size: 0.75rem;
+  font-weight: 600;
   white-space: nowrap;
   flex-shrink: 0;
 }

--- a/worker.js
+++ b/worker.js
@@ -11,8 +11,12 @@
  *    essay.html の WORKER_URL に貼り付ける
  */
 
-// システムプロンプト生成関数（プレースホルダーなし）
-function getBasePrompt() {
+// ===================================================
+// タイプ別システムプロンプト生成関数
+// ===================================================
+
+// 自由英作文用：既存プロンプト
+function getFreeEssayPrompt() {
   return `# 自由英作文 添削プロンプト
 ## 役割
 あなたは、明るい関西弁と温和な人柄が人気の、大学入試予備校の英語講師です。一人称は「ワイ」です。生徒が書いた英作文を添削し、学習に役立つプリントを作成します。
@@ -76,6 +80,93 @@ function getLevelInstructions(types) {
   return types.map(t => LEVEL_DEFINITIONS[t]?.instruction || '').filter(Boolean).join('\n');
 }
 
+// 和文英訳用プロンプト
+function getTranslationPrompt() {
+  return `# 和文英訳 添削プロンプト
+## 役割
+あなたは、明るい関西弁と温和な人柄が人気の、大学入試予備校の英語講師です。一人称は「ワイ」です。生徒の和文英訳を添削し、学習に役立つプリントを作成します。
+
+## 目的
+高校３年生の和文英訳を添削し、以下の観点で指導する。
+- **日本語の正確な理解**（日本語テキストの意味を正確に捉えているか）
+- **自然で正確な英訳**（文法・語法・表現が正確か）
+- **翻訳の多様性**（複数の自然な訳し方の提示）
+
+## 指導方針
+- 華麗な英語よりも**減点されない英語**を最優先とする。
+- 確実に書ける表現で得点を確保する戦略を徹底する。
+- 文法上の誤り・不自然な表現は全て指摘する。
+
+## 実行手順
+### 1. 日本語テキストの分析
+与えられた日本語の意味・文構造・重要表現を分析する。
+
+### 2. 学生の英訳評価
+- 日本語を正確に理解しているか。
+- 文法・語法は正しいか。
+- 表現は自然か。
+
+### 3. 添削・解説
+以下の観点で、ミスを**全て**列挙する。各ミスについて、①誤りの箇所→②なぜ誤りか→③正しい表現、の順で解説する。
+**文法・語法：** 主語と動詞の一致、時制、態、冠詞、前置詞、代名詞など
+**表記：** スペルミス、句読法、大文字・小文字
+**語彙・表現：** 不自然な英語表現、直訳調の表現
+
+### 4. 複数の訳例提示
+日本語の意味を正確に伝えながら、異なるアプローチでの自然な英訳例を2〜3つ提示する。
+
+## 制約条件
+- **言語**：解説と指導は全て日本語で行う。
+- **トーン**：明るい関西弁で、一人称は「ワイ」。生徒に寄り添い、良い点は都度褒める。
+- **チャット**：次の入力を促す表現は不要。
+- **出力形式**：各ステップを見出しで分け、全体をMarkdownで整形する。`;
+}
+
+// 図表付き英作文用プロンプト
+function getDiagramEssayPrompt() {
+  return `# 図表付き英作文 添削プロンプト
+## 役割
+あなたは、明るい関西弁と温和な人柄が人気の、大学入試予備校の英語講師です。一人称は「ワイ」です。生徒が書いた図表付き英作文を添削し、学習に役立つプリントを作成します。
+
+## 目的
+高校３年生の図表付き英作文を添削し、以下の観点で指導する。
+- **図表の読み取り正確性**（グラフ・表・画像の数値・情報を正確に把握しているか）
+- **課題への適切さ**（図表の説明が設問の要求に対応しているか）
+- **論理の整合性**（データに基づいた論理展開になっているか）
+
+## 指導方針
+- 華麗な英語よりも**減点されない英語**を最優先とする。
+- 図表データの読み取り精度を最重視する。
+- 文法上の誤り・論理の甘さは全て指摘する。
+
+## 実行手順
+### 1. 図表の分析
+提供された図表・画像から以下を抽出する。
+- 図表の種類（グラフ、表、画像など）
+- 主要な数値・データ・情報
+- 図表が示すトレンドや関係性
+
+### 2. 学生の読み取り評価
+- 図表データを正確に把握しているか。
+- 説明に誤読や見落としがないか。
+- データに基づいた適切な解釈をしているか。
+
+### 3. 内容評価
+- 設問の要求に対して適切に答えているか。
+- 図表の情報を効果的に活用しているか。
+- 論理に矛盾や飛躍がないか。
+
+### 4. 添削・解説
+【サンプルプロンプト - 後で自分で設定】
+ここに添削指導内容を追加してください。
+
+## 制約条件
+- **言語**：解説と指導は全て日本語で行う。
+- **トーン**：明るい関西弁で、一人称は「ワイ」。生徒に寄り添い、良い点は都度褒める。
+- **チャット**：次の入力を促す表現は不要。
+- **出力形式**：各ステップを見出しで分け、全体をMarkdownで整形する。`;
+}
+
 // タイプ別の解答例指示文を定義
 const LEVEL_DEFINITIONS = {
   A: {
@@ -110,14 +201,13 @@ const LEVEL_DEFINITIONS = {
   },
 };
 
-// 選択されたタイプに基づいて SYSTEM_PROMPT を生成
-function generateSystemPrompt(types, customInstruction = '') {
-  const basePrompt = getBasePrompt();
+// 自由英作文のシステムプロンプト生成
+function generateFreeEssayPrompt(types, customInstruction = '') {
+  const basePrompt = getFreeEssayPrompt();
   const levelInstructions = getLevelInstructions(types);
 
   let systemPrompt = basePrompt + levelInstructions;
 
-  // カスタム指定があれば追加
   if (customInstruction && customInstruction.trim()) {
     systemPrompt += `
 ### 6.5. カスタム指定
@@ -125,7 +215,6 @@ function generateSystemPrompt(types, customInstruction = '') {
 ${customInstruction.trim()}`;
   }
 
-  // セクション7以降を追加
   systemPrompt += `
 ### 7. 次回への教訓
 今回のミスから抽出した、**他の問題にも応用できる**アドバイス・汎用表現・注意点を3〜5つ紹介する。単なるミスの振り返りではなく、今後の英作文全般に活きる知識として提示する。
@@ -144,6 +233,18 @@ ${customInstruction.trim()}`;
   return systemPrompt;
 }
 
+// タイプに応じてシステムプロンプトを生成
+function generateSystemPrompt(essayType, payload) {
+  if (essayType === 'free-essay') {
+    return generateFreeEssayPrompt(payload.types || [], payload.customInstruction || '');
+  } else if (essayType === 'translation') {
+    return getTranslationPrompt();
+  } else if (essayType === 'diagram-essay') {
+    return getDiagramEssayPrompt();
+  }
+  return getFreeEssayPrompt();
+}
+
 export default {
   async fetch(request, env) {
     // CORS プリフライト対応
@@ -159,11 +260,13 @@ export default {
     if (request.method !== 'POST') {
       return new Response('Method Not Allowed', { status: 405 });
     }
-    let question, answer, types, customInstruction;
+
+    let essayType, payload;
     try {
-      ({ question = '', answer, types = [], customInstruction = '' } = await request.json());
-      if (!answer) throw new Error('answer is required');
-      console.log('[Worker] Request received. Types:', types, 'HasCustomInstruction:', !!customInstruction);
+      payload = await request.json();
+      essayType = payload.essayType;
+      if (!essayType) throw new Error('essayType is required');
+      console.log('[Worker] Request received. EssayType:', essayType);
     } catch (e) {
       console.error('[Worker] Request parse error:', e.message);
       return new Response(JSON.stringify({ error: 'リクエストが不正です' }), {
@@ -171,11 +274,51 @@ export default {
         headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
       });
     }
-    const userMessage = question
-      ? `【問題文】\n${question}\n\n【あなたの解答】\n${answer}`
-      : `【あなたの解答】\n${answer}`;
 
-    const systemPrompt = generateSystemPrompt(types, customInstruction);
+    // タイプに応じてユーザーメッセージを構築
+    let userMessage = '';
+    let userContent = [];
+
+    if (essayType === 'free-essay') {
+      const { question = '', answer } = payload;
+      if (!answer) throw new Error('answer is required');
+      userMessage = question
+        ? `【問題文】\n${question}\n\n【あなたの解答】\n${answer}`
+        : `【あなたの解答】\n${answer}`;
+      userContent = [{ type: 'text', text: userMessage }];
+
+    } else if (essayType === 'translation') {
+      const { japaneseText, answer } = payload;
+      if (!japaneseText || !answer) throw new Error('japaneseText and answer are required');
+      userMessage = `【日本語テキスト】\n${japaneseText}\n\n【あなたの英訳】\n${answer}`;
+      userContent = [{ type: 'text', text: userMessage }];
+
+    } else if (essayType === 'diagram-essay') {
+      const { question = '', answer, imageBase64 } = payload;
+      if (!answer) throw new Error('answer is required');
+      if (!imageBase64) throw new Error('imageBase64 is required');
+
+      userContent = [
+        {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: 'image/jpeg', // または他の形式に応じて調整
+            data: imageBase64.split(',')[1], // data:image/...の部分を削除
+          },
+        },
+        {
+          type: 'text',
+          text: question
+            ? `【問題文】\n${question}\n\n【あなたの解答】\n${answer}`
+            : `【あなたの解答】\n${answer}`,
+        },
+      ];
+    } else {
+      throw new Error('Invalid essayType');
+    }
+
+    const systemPrompt = generateSystemPrompt(essayType, payload);
     console.log('[Worker] System prompt generated. Length:', systemPrompt.length);
 
     const apiRes = await fetch('https://api.anthropic.com/v1/messages', {
@@ -191,7 +334,7 @@ export default {
         max_tokens: 8192,
         stream: true,
         system: systemPrompt,
-        messages: [{ role: 'user', content: userMessage }],
+        messages: [{ role: 'user', content: userContent }],
       }),
     });
 


### PR DESCRIPTION
…and diagram-based essay

Features:
- Add tab-based UI to switch between three essay types
- Free essay: Existing functionality with solution type selection (A-E)
- Japanese-to-English translation: Two-field form (Japanese text + English translation)
- Diagram-based essay: Question, essay text, and image upload (file select, drag-drop, camera)
- Support image upload with preview and deletion options
- Store essay type information in history with type badge display
- Update Cloudflare Worker to handle three different essay types with appropriate prompts:
  - Free essay: Use existing prompt with level-based guidance
  - Translation: Sample prompt for translation feedback (user configurable)
  - Diagram essay: Sample prompt with image processing (user configurable feedback)
- Implement image Base64 encoding for diagram essay submission to Claude API
- Add responsive CSS for tab navigation, image upload area, and type badges
- Add dark mode support for new UI components

https://claude.ai/code/session_01NHvPzoh3F8hmWR4uDwDSzi