### PR TITLE
Add solution type selection (A-E) to translation and diagram essay types

### DIFF
--- a/essay.html
+++ b/essay.html
@@ -129,6 +129,32 @@
             placeholder="英訳をここに入力してください…"></textarea>
         </div>
 
+        <div class="form-group">
+          <label>解答例タイプ（複数選択可）</label>
+          <div class="checkbox-group">
+            <label class="checkbox-label">
+              <input type="checkbox" id="trans-type-A" name="trans-types" value="A" checked>
+              A（原文ベース）
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="trans-type-B" name="trans-types" value="B">
+              B（英検2級）
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="trans-type-C" name="trans-types" value="C">
+              C（英検準1級）
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="trans-type-D" name="trans-types" value="D">
+              D（英検1級）
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="trans-type-E" name="trans-types" value="E">
+              E（別アプローチ版）
+            </label>
+          </div>
+        </div>
+
         <button class="btn-submit" onclick="submitEssay('translation')">✏️ 添削する</button>
       </div>
 
@@ -162,6 +188,32 @@
           <label for="answer-diagram">あなたの作品</label>
           <textarea id="answer-diagram" class="essay-textarea essay-textarea--answer" rows="10"
             placeholder="英作文をここに入力してください…"></textarea>
+        </div>
+
+        <div class="form-group">
+          <label>解答例タイプ（複数選択可）</label>
+          <div class="checkbox-group">
+            <label class="checkbox-label">
+              <input type="checkbox" id="diagram-type-A" name="diagram-types" value="A" checked>
+              A（原文ベース）
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="diagram-type-B" name="diagram-types" value="B">
+              B（英検2級）
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="diagram-type-C" name="diagram-types" value="C">
+              C（英検準1級）
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="diagram-type-D" name="diagram-types" value="D">
+              D（英検1級）
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="diagram-type-E" name="diagram-types" value="E">
+              E（別アプローチ版）
+            </label>
+          </div>
         </div>
 
         <button class="btn-submit" onclick="submitEssay('diagram-essay')">✏️ 添削する</button>
@@ -401,10 +453,14 @@
           return;
         }
 
+        const transCheckboxes = document.querySelectorAll('input[name="trans-types"]:checked');
+        const transTypes = Array.from(transCheckboxes).map(cb => cb.value);
+
         payload = {
           essayType: 'translation',
           japaneseText,
-          answer
+          answer,
+          types: transTypes
         };
 
       } else if (tabType === 'diagram-essay') {
@@ -421,11 +477,15 @@
           return;
         }
 
+        const diagramCheckboxes = document.querySelectorAll('input[name="diagram-types"]:checked');
+        const diagramTypes = Array.from(diagramCheckboxes).map(cb => cb.value);
+
         payload = {
           essayType: 'diagram-essay',
           question,
           answer,
-          imageBase64: uploadedImageBase64
+          imageBase64: uploadedImageBase64,
+          types: diagramTypes
         };
       }
 

--- a/worker.js
+++ b/worker.js
@@ -81,8 +81,8 @@ function getLevelInstructions(types) {
 }
 
 // 和文英訳用プロンプト
-function getTranslationPrompt() {
-  return `# 和文英訳 添削プロンプト
+function getTranslationPrompt(types = []) {
+  const basePrompt = `# 和文英訳 添削プロンプト
 ## 役割
 あなたは、明るい関西弁と温和な人柄が人気の、大学入試予備校の英語講師です。一人称は「ワイ」です。生徒の和文英訳を添削し、学習に役立つプリントを作成します。
 
@@ -113,7 +113,12 @@ function getTranslationPrompt() {
 **語彙・表現：** 不自然な英語表現、直訳調の表現
 
 ### 4. 複数の訳例提示
-日本語の意味を正確に伝えながら、異なるアプローチでの自然な英訳例を2〜3つ提示する。
+日本語の意味を正確に伝えながら、異なるアプローチでの自然な英訳例を2〜3つ提示する。`;
+
+  const levelInstructions = getLevelInstructions(types);
+  const fullPrompt = basePrompt + (levelInstructions ? '\n\n' + levelInstructions : '');
+
+  return fullPrompt + `
 
 ## 制約条件
 - **言語**：解説と指導は全て日本語で行う。
@@ -123,8 +128,8 @@ function getTranslationPrompt() {
 }
 
 // 図表付き英作文用プロンプト
-function getDiagramEssayPrompt() {
-  return `# 図表付き英作文 添削プロンプト
+function getDiagramEssayPrompt(types = []) {
+  const basePrompt = `# 図表付き英作文 添削プロンプト
 ## 役割
 あなたは、明るい関西弁と温和な人柄が人気の、大学入試予備校の英語講師です。一人称は「ワイ」です。生徒が書いた図表付き英作文を添削し、学習に役立つプリントを作成します。
 
@@ -158,7 +163,12 @@ function getDiagramEssayPrompt() {
 
 ### 4. 添削・解説
 【サンプルプロンプト - 後で自分で設定】
-ここに添削指導内容を追加してください。
+ここに添削指導内容を追加してください。`;
+
+  const levelInstructions = getLevelInstructions(types);
+  const fullPrompt = basePrompt + (levelInstructions ? '\n\n' + levelInstructions : '');
+
+  return fullPrompt + `
 
 ## 制約条件
 - **言語**：解説と指導は全て日本語で行う。
@@ -238,9 +248,9 @@ function generateSystemPrompt(essayType, payload) {
   if (essayType === 'free-essay') {
     return generateFreeEssayPrompt(payload.types || [], payload.customInstruction || '');
   } else if (essayType === 'translation') {
-    return getTranslationPrompt();
+    return getTranslationPrompt(payload.types || []);
   } else if (essayType === 'diagram-essay') {
-    return getDiagramEssayPrompt();
+    return getDiagramEssayPrompt(payload.types || []);
   }
   return getFreeEssayPrompt();
 }


### PR DESCRIPTION
- Add checkbox groups for types A-E in translation and diagram-essay tabs
- Update submitEssay() to collect selected types from translation and diagram essay forms
- Modify getTranslationPrompt() and getDiagramEssayPrompt() to accept types parameter
- Apply level-based guidance instructions to translation and diagram essay prompts
- Pass types to generateSystemPrompt() for all essay types

Now users can select solution examples at their preferred level for all three essay types: free essay, translation, and diagram-based essay.

https://claude.ai/code/session_01NHvPzoh3F8hmWR4uDwDSzi