### PR TITLE
Improve OCR textarea size for iPhone/Safari editing

### DIFF
--- a/essay.html
+++ b/essay.html
@@ -60,7 +60,7 @@
 
     .ocr-result-display { margin: 1.5rem 0; padding: 1rem; background: var(--color-ocr-bg, #fff9e6); border-left: 4px solid var(--color-ocr-border, #ffc107); border-radius: 4px; }
     .ocr-result-display h3 { margin: 0 0 1rem 0; font-size: 1rem; }
-    .ocr-result-display textarea { width: 100%; min-height: 150px; padding: 0.5rem; border: 1px solid var(--color-border-light, #ddd); border-radius: 4px; font-family: monospace; font-size: 0.9rem; }
+    .ocr-result-display textarea { width: 100%; min-height: 400px; padding: 0.75rem; border: 1px solid var(--color-border-light, #ddd); border-radius: 4px; font-family: monospace; font-size: 0.9rem; resize: vertical; box-sizing: border-box; }
     .ocr-result-display p.note { margin: 0.5rem 0 0 0; font-size: 0.85rem; color: var(--color-text-sub, #666); }
 
     /* OCRローディング */
@@ -76,6 +76,7 @@
     .essay-textarea:focus { outline: none; border-color: #007bff; box-shadow: 0 0 0 3px rgba(0,123,255,0.1); }
     @media (max-width: 600px) {
       .essay-textarea { min-height: 280px; font-size: 16px; }
+      .ocr-result-display textarea { min-height: 60vh; font-size: 14px; -webkit-overflow-scrolling: touch; }
     }
 
     /* 問題タイプ選択 */


### PR DESCRIPTION
- Desktop: min-height 150px → 400px (approx 20 lines)
- Mobile (≤600px): min-height 60vh, font-size 14px
- Add resize: vertical and -webkit-overflow-scrolling: touch
- Increase padding to 0.75rem for easier touch tapping