### PR TITLE
Fix OCR to support JPEG, PNG, GIF, WebP correctly

### DIFF
--- a/essay.html
+++ b/essay.html
@@ -185,10 +185,11 @@
           <div class="form-group">
             <label>問題文の画像をアップロード</label>
             <div class="image-upload-area" id="question-upload-area" onclick="triggerFileInput('question')" ondrop="handleDrop(event)" ondragover="handleDragOver(event)" ondragleave="handleDragLeave(event)">
-              <input type="file" id="question-image-input" accept="image/*" onchange="handleImageUpload(event, 'question')" class="hidden">
+              <input type="file" id="question-image-input" accept="image/jpeg,image/png,image/gif,image/webp" onchange="handleImageUpload(event, 'question')" class="hidden">
               <div class="upload-placeholder">
                 <p>📸 タップして画像を選択</p>
                 <p class="upload-hint">またはドラッグ&ドロップ</p>
+                <p class="upload-hint">対応形式: JPEG, PNG, GIF, WebP</p>
               </div>
               <div id="question-image-preview" class="image-preview" class="hidden"></div>
             </div>
@@ -242,10 +243,11 @@
           <div class="form-group">
             <label>解答の画像をアップロード</label>
             <div class="image-upload-area" id="answer-upload-area" onclick="triggerFileInput('answer')" ondrop="handleDrop(event)" ondragover="handleDragOver(event)" ondragleave="handleDragLeave(event)">
-              <input type="file" id="answer-image-input" accept="image/*" onchange="handleImageUpload(event, 'answer')" class="hidden">
+              <input type="file" id="answer-image-input" accept="image/jpeg,image/png,image/gif,image/webp" onchange="handleImageUpload(event, 'answer')" class="hidden">
               <div class="upload-placeholder">
                 <p>📸 タップして画像を選択</p>
                 <p class="upload-hint">またはドラッグ&ドロップ</p>
+                <p class="upload-hint">対応形式: JPEG, PNG, GIF, WebP</p>
               </div>
               <div id="answer-image-preview" class="image-preview" class="hidden"></div>
             </div>
@@ -547,8 +549,9 @@
       if (!file) return;
 
       // ファイル形式・サイズチェック
-      if (!file.type.startsWith('image/')) {
-        alert('画像ファイルを選択してください。');
+      const SUPPORTED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+      if (!SUPPORTED_TYPES.includes(file.type)) {
+        alert('対応していないファイル形式です。\nJPEG, PNG, GIF, WebP の画像を選択してください。');
         return;
       }
       if (file.size > 10 * 1024 * 1024) {

--- a/worker.js
+++ b/worker.js
@@ -408,6 +408,9 @@ function buildUserContent(essayType, payload) {
     const { question = '', answer, imageBase64 } = payload;
     if (!answer) throw new Error('answer is required');
     if (!imageBase64) throw new Error('imageBase64 is required');
+    const mediaType = imageBase64.split(';')[0].split(':')[1];
+    const SUPPORTED = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+    if (!SUPPORTED.includes(mediaType)) throw new Error(`Unsupported image type: ${mediaType}`);
     const text = question
       ? `【問題文】\n${question}\n\n【あなたの解答】\n${answer}`
       : `【あなたの解答】\n${answer}`;
@@ -416,7 +419,7 @@ function buildUserContent(essayType, payload) {
         type: 'image',
         source: {
           type: 'base64',
-          media_type: 'image/jpeg',
+          media_type: mediaType,
           data: imageBase64.split(',')[1],
         },
       },
@@ -426,12 +429,15 @@ function buildUserContent(essayType, payload) {
   if (essayType === 'diagram-ocr') {
     const { imageBase64 } = payload;
     if (!imageBase64) throw new Error('imageBase64 is required');
+    const mediaType = imageBase64.split(';')[0].split(':')[1];
+    const SUPPORTED = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+    if (!SUPPORTED.includes(mediaType)) throw new Error(`Unsupported image type: ${mediaType}`);
     return [
       {
         type: 'image',
         source: {
           type: 'base64',
-          media_type: 'image/jpeg',
+          media_type: mediaType,
           data: imageBase64.split(',')[1],
         },
       },


### PR DESCRIPTION
- worker.js: extract media_type dynamically from base64 data URL instead of hardcoding image/jpeg; add validation for unsupported types
- essay.html: restrict accept attribute to the 4 supported formats, add format hint text in upload area, tighten client-side type check

https://claude.ai/code/session_01L8meDYSaNwY7XpQ62XWokJ