### PR TITLE
Expand OCR correction box to full step-container width

### DIFF
--- a/essay.html
+++ b/essay.html
@@ -58,7 +58,7 @@
     .btn-remove-image { margin-top: 0.5rem; padding: 0.3rem 0.6rem; font-size: 0.85rem; background: #dc3545; color: white; border: none; border-radius: 3px; cursor: pointer; }
     .btn-remove-image:hover { background: #c82333; }
 
-    .ocr-result-display { margin: 1.5rem 0; padding: 1rem; background: var(--color-ocr-bg, #fff9e6); border-left: 4px solid var(--color-ocr-border, #ffc107); border-radius: 4px; }
+    .ocr-result-display { margin: 1.5rem -2rem; padding: 1rem 2rem; background: var(--color-ocr-bg, #fff9e6); border-top: 4px solid var(--color-ocr-border, #ffc107); border-radius: 0; }
     .ocr-result-display h3 { margin: 0 0 1rem 0; font-size: 1rem; }
     .ocr-result-display textarea { width: 100%; min-height: 400px; padding: 0.75rem; border: 1px solid var(--color-border-light, #ddd); border-radius: 4px; font-family: monospace; font-size: 0.9rem; resize: vertical; box-sizing: border-box; -webkit-overflow-scrolling: touch; }
     .ocr-result-display p.note { margin: 0.5rem 0 0 0; font-size: 0.85rem; color: var(--color-text-sub, #666); }
@@ -123,6 +123,7 @@
       .step-actions { flex-direction: column; }
       .btn-action { width: 100%; }
       .level-checkboxes { flex-direction: column; gap: 0.75rem; }
+      .ocr-result-display { margin-left: -1.5rem; margin-right: -1.5rem; padding-left: 1.5rem; padding-right: 1.5rem; }
     }
   </style>
 </head>


### PR DESCRIPTION
Use negative horizontal margins on .ocr-result-display to break out of .step-container padding, giving the editable textarea the full card width. Also switch the yellow accent from border-left to border-top to suit the full-width layout. Includes responsive adjustment for the narrower 1.5rem padding applied at ≤768 px.

https://claude.ai/code/session_01URe6j67DUsQT2yzRPkGCj4