### PR TITLE
Widen OCR box one more level to essay-section edge

### DIFF
--- a/essay.html
+++ b/essay.html
@@ -58,7 +58,7 @@
     .btn-remove-image { margin-top: 0.5rem; padding: 0.3rem 0.6rem; font-size: 0.85rem; background: #dc3545; color: white; border: none; border-radius: 3px; cursor: pointer; }
     .btn-remove-image:hover { background: #c82333; }
 
-    .ocr-result-display { margin: 1.5rem -2rem; padding: 1rem 2rem; background: var(--color-ocr-bg, #fff9e6); border-top: 4px solid var(--color-ocr-border, #ffc107); border-radius: 0; }
+    .ocr-result-display { margin: 1.5rem -3rem; padding: 1rem 3rem; background: var(--color-ocr-bg, #fff9e6); border-top: 4px solid var(--color-ocr-border, #ffc107); border-radius: 0; }
     .ocr-result-display h3 { margin: 0 0 1rem 0; font-size: 1rem; }
     .ocr-result-display textarea { width: 100%; min-height: 400px; padding: 0.75rem; border: 1px solid var(--color-border-light, #ddd); border-radius: 4px; font-family: monospace; font-size: 0.9rem; resize: vertical; box-sizing: border-box; -webkit-overflow-scrolling: touch; }
     .ocr-result-display p.note { margin: 0.5rem 0 0 0; font-size: 0.85rem; color: var(--color-text-sub, #666); }
@@ -123,7 +123,7 @@
       .step-actions { flex-direction: column; }
       .btn-action { width: 100%; }
       .level-checkboxes { flex-direction: column; gap: 0.75rem; }
-      .ocr-result-display { margin-left: -1.5rem; margin-right: -1.5rem; padding-left: 1.5rem; padding-right: 1.5rem; }
+      .ocr-result-display { margin-left: -2.5rem; margin-right: -2.5rem; padding-left: 2.5rem; padding-right: 2.5rem; }
     }
   </style>
 </head>


### PR DESCRIPTION
Increase negative horizontal margin from -2rem to -3rem (desktop) and from -1.5rem to -2.5rem (mobile) so the OCR correction textarea now spans the full width of .essay-section, absorbing its 1rem side padding.

https://claude.ai/code/session_01URe6j67DUsQT2yzRPkGCj4