### PR TITLE
Stretch OCR textarea edge-to-edge within ocr-result-display

### DIFF
--- a/essay.html
+++ b/essay.html
@@ -58,10 +58,10 @@
     .btn-remove-image { margin-top: 0.5rem; padding: 0.3rem 0.6rem; font-size: 0.85rem; background: #dc3545; color: white; border: none; border-radius: 3px; cursor: pointer; }
     .btn-remove-image:hover { background: #c82333; }
 
-    .ocr-result-display { margin: 1.5rem -3rem; padding: 1.25rem 3rem; background: var(--color-bg, #f0f4f8); border-top: 3px solid var(--color-accent, #2563eb); border-radius: 0; }
-    .ocr-result-display h3 { margin: 0 0 1rem 0; font-size: 1rem; }
-    .ocr-result-display textarea { width: 100%; min-height: 400px; padding: 0.75rem; border: 1px solid var(--color-border-light, #ddd); border-radius: 4px; font-family: monospace; font-size: 0.9rem; resize: vertical; box-sizing: border-box; -webkit-overflow-scrolling: touch; }
-    .ocr-result-display p.note { margin: 0.5rem 0 0 0; font-size: 0.85rem; color: var(--color-text-sub, #666); }
+    .ocr-result-display { margin: 1.5rem -3rem; padding: 1.25rem 0; background: var(--color-bg, #f0f4f8); border-top: 3px solid var(--color-accent, #2563eb); border-radius: 0; }
+    .ocr-result-display h3 { margin: 0 0 0.75rem 0; font-size: 1rem; padding: 0 1rem; }
+    .ocr-result-display textarea { width: 100%; min-height: 400px; padding: 0.75rem 1rem; border: none; border-top: 1px solid var(--color-border, #e2e8f0); border-bottom: 1px solid var(--color-border, #e2e8f0); border-radius: 0; font-family: monospace; font-size: 0.9rem; resize: vertical; box-sizing: border-box; -webkit-overflow-scrolling: touch; background: var(--color-surface, #fff); color: var(--color-text, #1e293b); }
+    .ocr-result-display p.note { margin: 0.5rem 0 0 0; font-size: 0.85rem; color: var(--color-text-sub, #666); padding: 0 1rem; }
     @media (max-width: 600px) {
       .ocr-result-display textarea { min-height: 60vh; font-size: 14px; padding: 0.75rem; }
     }
@@ -123,7 +123,7 @@
       .step-actions { flex-direction: column; }
       .btn-action { width: 100%; }
       .level-checkboxes { flex-direction: column; gap: 0.75rem; }
-      .ocr-result-display { margin-left: -2.5rem; margin-right: -2.5rem; padding-left: 2.5rem; padding-right: 2.5rem; }
+      .ocr-result-display { margin-left: -2.5rem; margin-right: -2.5rem; padding-left: 0; padding-right: 0; }
     }
   </style>
 </head>


### PR DESCRIPTION
Remove side padding from .ocr-result-display and give h3/note their own 1rem padding instead. The textarea now fills the full width with no side borders, creating a flush editor look. Background matches --color-surface so it pops against the --color-bg grey section.

https://claude.ai/code/session_01URe6j67DUsQT2yzRPkGCj4