### PR TITLE
添削フォームをシングルページ化・セクション順を変更

### DIFF
--- a/essay.html
+++ b/essay.html
@@ -72,132 +72,9 @@
         </div>
       </details>
 
-      <!-- ===== ステップ1: 問題文入力 ===== -->
-
-
-      <!-- ===== ステップ1: 問題文入力 ===== -->
-      <div id="step-1" class="step-container active">
+      <!-- ===== セクション1: 問題タイプ選択 ===== -->
+      <div id="step-3" class="step-container active">
         <div class="step-header">
-          <div class="step-number">ステップ 1 / 3</div>
-          <h3 class="step-title">📝 問題文の入力</h3>
-        </div>
-
-        <div class="form-group">
-          <label>入力方法</label>
-          <div class="input-mode-tabs">
-            <button class="mode-btn active" data-mode="text" data-field="question" onclick="switchInputMode(event)">✋ 手入力</button>
-            <button class="mode-btn" data-mode="image" data-field="question" onclick="switchInputMode(event)">📸 画像アップロード</button>
-          </div>
-        </div>
-
-        <!-- 手入力モード -->
-        <div id="question-text-mode" class="input-mode active">
-          <div class="form-group">
-            <label for="question-text-input">問題文を入力</label>
-            <textarea id="question-text-input" class="essay-textarea" rows="6" placeholder="例: Describe the advantages of studying abroad in about 100 words."></textarea>
-          </div>
-        </div>
-
-        <!-- 画像モード -->
-        <div id="question-image-mode" class="input-mode">
-          <div class="form-group">
-            <label>問題文の画像をアップロード</label>
-            <div class="image-upload-area" id="question-upload-area" onclick="triggerFileInput('question')" ondrop="handleDrop(event)" ondragover="handleDragOver(event)" ondragleave="handleDragLeave(event)">
-              <input type="file" id="question-image-input" accept="image/jpeg,image/png,image/gif,image/webp" onchange="handleImageUpload(event, 'question')" class="hidden">
-              <div class="upload-placeholder">
-                <p>📸 タップして画像を選択</p>
-                <p class="upload-hint">またはドラッグ&ドロップ</p>
-                <p class="upload-hint">対応形式: JPEG, PNG, GIF, WebP</p>
-              </div>
-              <div id="question-image-preview" class="image-preview" class="hidden"></div>
-            </div>
-            <div style="margin-top: 1rem;">
-              <button class="btn-action btn-next" onclick="document.getElementById('question-image-input').click()">📁 ファイルを選択</button>
-            </div>
-            <div id="question-ocr-loading" class="ocr-loading">
-              <div class="ocr-loading-spinner"></div>
-              <p class="ocr-loading-text">画像を読み取っています…</p>
-            </div>
-            <div id="question-ocr-display" class="hidden">
-              <div class="ocr-result-display">
-                <h3>📋 OCR読み取り結果（修正してください）</h3>
-                <textarea id="question-ocr-text" class="essay-textarea" rows="6"></textarea>
-                <p class="note">※ 不正確な部分を修正してください</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="step-actions">
-          <button class="btn-action btn-next" onclick="goToStep(2)">次へ →</button>
-        </div>
-      </div>
-
-      <!-- ===== ステップ2: 解答入力 ===== -->
-      <div id="step-2" class="step-container">
-        <div class="step-header">
-          <div class="step-number">ステップ 2 / 3</div>
-          <h3 class="step-title">✏️ あなたの解答</h3>
-        </div>
-
-        <div class="form-group">
-          <label>入力方法</label>
-          <div class="input-mode-tabs">
-            <button class="mode-btn active" data-mode="text" data-field="answer" onclick="switchInputMode(event)">✋ 手入力</button>
-            <button class="mode-btn" data-mode="image" data-field="answer" onclick="switchInputMode(event)">📸 画像アップロード</button>
-          </div>
-        </div>
-
-        <!-- 手入力モード -->
-        <div id="answer-text-mode" class="input-mode active">
-          <div class="form-group">
-            <label for="answer-text-input">解答を入力</label>
-            <textarea id="answer-text-input" class="essay-textarea" rows="10" placeholder="英作文（またはあなたの英訳）をここに入力してください…"></textarea>
-            <div id="word-count-display" class="word-count">語数: 0語</div>
-            <div id="draft-indicator" class="draft-indicator"></div>
-          </div>
-        </div>
-
-        <!-- 画像モード -->
-        <div id="answer-image-mode" class="input-mode">
-          <div class="form-group">
-            <label>解答の画像をアップロード</label>
-            <div class="image-upload-area" id="answer-upload-area" onclick="triggerFileInput('answer')" ondrop="handleDrop(event)" ondragover="handleDragOver(event)" ondragleave="handleDragLeave(event)">
-              <input type="file" id="answer-image-input" accept="image/jpeg,image/png,image/gif,image/webp" onchange="handleImageUpload(event, 'answer')" class="hidden">
-              <div class="upload-placeholder">
-                <p>📸 タップして画像を選択</p>
-                <p class="upload-hint">またはドラッグ&ドロップ</p>
-                <p class="upload-hint">対応形式: JPEG, PNG, GIF, WebP</p>
-              </div>
-              <div id="answer-image-preview" class="image-preview" class="hidden"></div>
-            </div>
-            <div style="margin-top: 1rem;">
-              <button class="btn-action btn-next" onclick="document.getElementById('answer-image-input').click()">📁 ファイルを選択</button>
-            </div>
-            <div id="answer-ocr-loading" class="ocr-loading">
-              <div class="ocr-loading-spinner"></div>
-              <p class="ocr-loading-text">画像を読み取っています…</p>
-            </div>
-            <div id="answer-ocr-display" class="hidden">
-              <div class="ocr-result-display">
-                <h3>📋 OCR読み取り結果（修正してください）</h3>
-                <textarea id="answer-ocr-text" class="essay-textarea" rows="10"></textarea>
-                <p class="note">※ 不正確な部分を修正してください</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="step-actions">
-          <button class="btn-action btn-back" onclick="goToStep(1)">← 戻る</button>
-          <button class="btn-action btn-next" onclick="goToStep(3)">次へ →</button>
-        </div>
-      </div>
-
-      <!-- ===== ステップ3: 問題タイプ選択 ===== -->
-      <div id="step-3" class="step-container">
-        <div class="step-header">
-          <div class="step-number">ステップ 3 / 3</div>
           <h3 class="step-title">🎯 問題タイプを選択</h3>
         </div>
 
@@ -311,11 +188,120 @@
             </div>
           </div>
         </div>
+      </div>
 
-        <div class="step-actions">
-          <button class="btn-action btn-back" onclick="goToStep(2)">← 戻る</button>
-          <button class="btn-action btn-submit" onclick="submitReview()" id="submit-btn">✏️ 添削を実行</button>
+      <!-- ===== セクション2: 問題文入力 ===== -->
+      <div id="step-1" class="step-container active">
+        <div class="step-header">
+          <h3 class="step-title">📝 問題文の入力</h3>
         </div>
+
+        <div class="form-group">
+          <label>入力方法</label>
+          <div class="input-mode-tabs">
+            <button class="mode-btn active" data-mode="text" data-field="question" onclick="switchInputMode(event)">✋ 手入力</button>
+            <button class="mode-btn" data-mode="image" data-field="question" onclick="switchInputMode(event)">📸 画像アップロード</button>
+          </div>
+        </div>
+
+        <!-- 手入力モード -->
+        <div id="question-text-mode" class="input-mode active">
+          <div class="form-group">
+            <label for="question-text-input">問題文を入力</label>
+            <textarea id="question-text-input" class="essay-textarea" rows="6" placeholder="例: Describe the advantages of studying abroad in about 100 words."></textarea>
+          </div>
+        </div>
+
+        <!-- 画像モード -->
+        <div id="question-image-mode" class="input-mode">
+          <div class="form-group">
+            <label>問題文の画像をアップロード</label>
+            <div class="image-upload-area" id="question-upload-area" onclick="triggerFileInput('question')" ondrop="handleDrop(event)" ondragover="handleDragOver(event)" ondragleave="handleDragLeave(event)">
+              <input type="file" id="question-image-input" accept="image/jpeg,image/png,image/gif,image/webp" onchange="handleImageUpload(event, 'question')" class="hidden">
+              <div class="upload-placeholder">
+                <p>📸 タップして画像を選択</p>
+                <p class="upload-hint">またはドラッグ&ドロップ</p>
+                <p class="upload-hint">対応形式: JPEG, PNG, GIF, WebP</p>
+              </div>
+              <div id="question-image-preview" class="image-preview" class="hidden"></div>
+            </div>
+            <div style="margin-top: 1rem;">
+              <button class="btn-action btn-next" onclick="document.getElementById('question-image-input').click()">📁 ファイルを選択</button>
+            </div>
+            <div id="question-ocr-loading" class="ocr-loading">
+              <div class="ocr-loading-spinner"></div>
+              <p class="ocr-loading-text">画像を読み取っています…</p>
+            </div>
+            <div id="question-ocr-display" class="hidden">
+              <div class="ocr-result-display">
+                <h3>📋 OCR読み取り結果（修正してください）</h3>
+                <textarea id="question-ocr-text" class="essay-textarea" rows="6"></textarea>
+                <p class="note">※ 不正確な部分を修正してください</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ===== セクション3: 解答入力 ===== -->
+      <div id="step-2" class="step-container active">
+        <div class="step-header">
+          <h3 class="step-title">✏️ あなたの解答</h3>
+        </div>
+
+        <div class="form-group">
+          <label>入力方法</label>
+          <div class="input-mode-tabs">
+            <button class="mode-btn active" data-mode="text" data-field="answer" onclick="switchInputMode(event)">✋ 手入力</button>
+            <button class="mode-btn" data-mode="image" data-field="answer" onclick="switchInputMode(event)">📸 画像アップロード</button>
+          </div>
+        </div>
+
+        <!-- 手入力モード -->
+        <div id="answer-text-mode" class="input-mode active">
+          <div class="form-group">
+            <label for="answer-text-input">解答を入力</label>
+            <textarea id="answer-text-input" class="essay-textarea" rows="10" placeholder="英作文（またはあなたの英訳）をここに入力してください…"></textarea>
+            <div id="word-count-display" class="word-count">語数: 0語</div>
+            <div id="draft-indicator" class="draft-indicator"></div>
+          </div>
+        </div>
+
+        <!-- 画像モード -->
+        <div id="answer-image-mode" class="input-mode">
+          <div class="form-group">
+            <label>解答の画像をアップロード</label>
+            <div class="image-upload-area" id="answer-upload-area" onclick="triggerFileInput('answer')" ondrop="handleDrop(event)" ondragover="handleDragOver(event)" ondragleave="handleDragLeave(event)">
+              <input type="file" id="answer-image-input" accept="image/jpeg,image/png,image/gif,image/webp" onchange="handleImageUpload(event, 'answer')" class="hidden">
+              <div class="upload-placeholder">
+                <p>📸 タップして画像を選択</p>
+                <p class="upload-hint">またはドラッグ&ドロップ</p>
+                <p class="upload-hint">対応形式: JPEG, PNG, GIF, WebP</p>
+              </div>
+              <div id="answer-image-preview" class="image-preview" class="hidden"></div>
+            </div>
+            <div style="margin-top: 1rem;">
+              <button class="btn-action btn-next" onclick="document.getElementById('answer-image-input').click()">📁 ファイルを選択</button>
+            </div>
+            <div id="answer-ocr-loading" class="ocr-loading">
+              <div class="ocr-loading-spinner"></div>
+              <p class="ocr-loading-text">画像を読み取っています…</p>
+            </div>
+            <div id="answer-ocr-display" class="hidden">
+              <div class="ocr-result-display">
+                <h3>📋 OCR読み取り結果（修正してください）</h3>
+                <textarea id="answer-ocr-text" class="essay-textarea" rows="10"></textarea>
+                <p class="note">※ 不正確な部分を修正してください</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="step-actions">
+        <button class="btn-action btn-submit" onclick="submitReview()" id="submit-btn">✏️ 添削を実行</button>
       </div>
 
       <!-- ===== 結果表示 ===== -->
@@ -372,58 +358,8 @@
       levels: ['A'],
       sections: ['summary', 'correction'],
       customInstruction: '',
-      dialect: 'kansai',
-      currentStep: 1
+      dialect: 'kansai'
     };
-
-    // ===================================================
-    // ステップ遷移
-    // ===================================================
-    function validateStepTransition(fromStep, toStep) {
-      if (fromStep === 1 && toStep === 2) {
-        // ステップ1→2: 問題文が必須
-        const questionText = getInputValue('question');
-        if (!questionText || questionText.trim() === '') {
-          alert('問題文を入力してください。');
-          return false;
-        }
-      }
-      if (fromStep === 2 && toStep === 3) {
-        // ステップ2→3: 英作文が必須
-        const answerText = getInputValue('answer');
-        if (!answerText || answerText.trim() === '') {
-          alert('英作文を入力してください。');
-          return false;
-        }
-      }
-      return true;
-    }
-
-    function goToStep(stepNum) {
-      if (stepNum < 1 || stepNum > 3) return;
-
-      // ステップ遷移のバリデーション
-      if (stepNum > AppState.currentStep && !validateStepTransition(AppState.currentStep, stepNum)) {
-        return;
-      }
-
-      // 現在のステップのデータを保存
-      if (AppState.currentStep === 1) {
-        AppState.question.text = getInputValue('question');
-      }
-      if (AppState.currentStep === 2) {
-        AppState.answer.text = getInputValue('answer');
-      }
-
-      // ステップを切り替え
-      document.querySelectorAll('.step-container').forEach(el => {
-        el.classList.remove('active');
-      });
-      document.getElementById(`step-${stepNum}`).classList.add('active');
-
-      AppState.currentStep = stepNum;
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
 
     // 入力値取得（手入力またはOCR修正後）
     function getInputValue(field) {
@@ -736,17 +672,17 @@
     // 添削実行
     // ===================================================
     async function submitReview() {
-      // 最新の入力値を取得
+      // 入力値を取得
       AppState.question.text = getInputValue('question');
       AppState.answer.text = getInputValue('answer');
 
       // バリデーション
       if (!AppState.question.text.trim()) {
-        alert('問題文を入力してください');
+        alert('問題文を入力してください。');
         return;
       }
       if (!AppState.answer.text.trim()) {
-        alert('解答を入力してください');
+        alert('解答を入力してください。');
         return;
       }
 
@@ -916,9 +852,12 @@
         document.getElementById(`${field}-ocr-loading`).classList.remove('active');
       });
 
-      // ステップ1へ
+      // フォームを再表示
       document.getElementById('result-view').classList.add('hidden');
-      goToStep(1);
+      document.querySelectorAll('.step-container').forEach(el => {
+        el.classList.add('active');
+      });
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     }
 
     // ===================================================

--- a/style.css
+++ b/style.css
@@ -1098,13 +1098,13 @@ footer {
 
 .hint { margin: 1rem 0; padding: 0.75rem; background: rgba(0,123,255,0.1); border-left: 3px solid #007bff; border-radius: 3px; font-size: 0.95rem; color: #0056b3; }
 
-.step-actions { display: flex; gap: 1rem; margin: 2rem 0; justify-content: space-between; }
+.step-actions { display: flex; gap: 1rem; margin: 2rem 0; justify-content: center; }
 .btn-action { padding: 0.75rem 1.5rem; border: none; border-radius: 4px; cursor: pointer; font-weight: bold; font-size: 1rem; transition: all 0.2s; }
 .btn-back { background: #6c757d; color: white; }
 .btn-back:hover { background: #5a6268; }
 .btn-next { background: #007bff; color: white; }
 .btn-next:hover { background: #0056b3; }
-.step-container .btn-submit { background: #28a745; color: white; }
+.step-container .btn-submit { background: #28a745; color: white; min-width: 180px; }
 .step-container .btn-submit:hover { background: #218838; }
 .step-container .btn-submit:disabled { background: #ccc; cursor: not-allowed; }
 


### PR DESCRIPTION
## Summary
- ステップ形式ウィザード（1/3 → 2/3 → 3/3）を廃止し、全フォームを一画面に表示
- 入力順を「問題タイプ → 出力セクション → 問題文 → 解答入力」に変更
- `goToStep()` / `validateStepTransition()` 関数を削除
- 送信ボタンを全セクションの下に配置

## Test plan
- [ ] 3つのセクションが縦並びで全て表示されることを確認
- [ ] フォーム入力 → 「添削を実行」で結果が同ページ内に表示されることを確認
- [ ] 「別の問題を解く」で全フォームが再表示されることを確認
- [ ] バリデーション（問題文なし・解答なし・セクション未選択）が機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)